### PR TITLE
fakedri could be patched now two ways with arg and env variable. Bug …

### DIFF
--- a/deployments/gpu_plugin/base/fakedri-patch.yaml
+++ b/deployments/gpu_plugin/base/fakedri-patch.yaml
@@ -17,12 +17,13 @@ spec:
         # FAKEDRI_SPEC simulates an Intel DG1 GPU with specific hardware specs for testing.
         - name: FAKEDRI_SPEC
           value: |
+            Path: "/tmp"
             Info: "8x 4 GiB DG1 [Iris Xe MAX Graphics] GPUs"  # Describes the fake GPU model
             DevCount: 8  # The number of fake GPUs being simulated (8 devices)
             TilesPerDev: 1  # Number of tiles per fake GPU (1 tile per device)
             DevsPerNode: 1  # Number of GPUs per node (1 GPU per numa node)
             DevMemSize: 4294967296  # Memory size per GPU in bytes (4 GiB = 4294967296 bytes)
-            Driver: "i915"  # The GPU driver to use for the fake device (i915, used for Intel GPUs)
+            Driver: "i915"  # The GPU driver to use for the fake device (xe, used for Intel DG1 GPUs)
             Capabilities:  # List of capabilities that the fake GPU supports
               platform: "fake_DG1"  # Fake platform name (simulates the DG1 platform)
               connections: ""  # Placeholder for GPU connections (manual connections for xe-link)

--- a/deployments/gpu_plugin/overlays/fractional_resources/add-fakedri-spec.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/add-fakedri-spec.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: intel-gpu-plugin
+spec:
+  template:
+    spec:
+      containers:
+      - name: intel-gpu-plugin
+        # All args must be here as K8s won't merge args other option is to use env variable FAKEDRI_SPEC which can patch freely
+        args:
+        - "-shared-dev-num=300"
+        - "-resource-manager"
+        - "-enable-monitoring"
+        # The --fakedri-spec argument simulates an Intel DG1 GPU with specific hardware specs for testing.
+        - |
+          --fakedri-spec=Info: "8x 4 GiB DG1 [Iris Xe MAX Graphics] GPUs"
+          Path: "/tmp" # Must be same as mounts and volumes
+          DevCount: 8
+          TilesPerDev: 1
+          DevsPerNode: 1
+          DevMemSize: 4294967296
+          Driver: "i915"
+          Capabilities:
+            platform: "fake_DG1"
+            connections: ""
+            connection-topology: "FULL"
+        volumeMounts:
+          - name: tmp
+            mountPath: /tmp  # The container's /tmp directory is mapped to the host's /tmp directory
+      volumes:
+      - name: tmp
+        hostPath:
+          path: /tmp  # Mount the host's /tmp directory inside the container
+          type: DirectoryOrCreate  # Create the directory if it does not already exist

--- a/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
+++ b/deployments/gpu_plugin/overlays/fractional_resources/kustomization.yaml
@@ -16,3 +16,7 @@ patches:
   - path: add-nodeselector-intel-gpu.yaml
     target:
       kind: DaemonSet
+  #- path: add-fakedri-spec.yaml  # Apply the fakedri-spec patch
+  #  target:
+  #    kind: DaemonSet
+  #    name: intel-gpu-plugin

--- a/pkg/deviceplugin/api.go
+++ b/pkg/deviceplugin/api.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 // NewDeviceInfo makes DeviceInfo struct and adds topology information to it.
-func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginapi.Mount, envs, annotations map[string]string, cdiSpec *cdispec.Spec) DeviceInfo {
+func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginapi.Mount, envs, annotations map[string]string, cdiSpec *cdispec.Spec, devPaths ...string) DeviceInfo {
 	deviceInfo := DeviceInfo{
 		state:       state,
 		nodes:       nodes,
@@ -58,13 +58,20 @@ func NewDeviceInfo(state string, nodes []pluginapi.DeviceSpec, mounts []pluginap
 		cdiSpec:     cdiSpec,
 	}
 
-	devPaths := []string{}
+	var devPathsComputed []string
 
-	for _, node := range nodes {
-		devPaths = append(devPaths, node.HostPath)
+	// If devPaths are provided, use them; otherwise, generate from nodes
+	if len(devPaths) > 0 && devPaths[0] != "" {
+		devPathsComputed = devPaths
+	} else {
+		devPathsComputed = []string{}
+		for _, node := range nodes {
+			devPathsComputed = append(devPathsComputed, node.HostPath)
+		}
 	}
 
-	topologyInfo, err := topology.GetTopologyInfo(devPaths)
+	// Get topology information based on devPaths
+	topologyInfo, err := topology.GetTopologyInfo(devPathsComputed)
 	if err == nil {
 		deviceInfo.topology = topologyInfo
 	} else {

--- a/pkg/fakedri/fakedri.go
+++ b/pkg/fakedri/fakedri.go
@@ -73,6 +73,8 @@ type GenOptions struct {
 	Capabilities map[string]string // map (pointer)
 	Info         string            // string (pointer)
 	Driver       string            // string (pointer)
+	Mode         string            // string (pointer)
+	Path         string            // string (pointer)
 
 	DevCount    int // int (non-pointer, 8 bytes on 64-bit systems)
 	TilesPerDev int // int
@@ -91,6 +93,8 @@ type genOptionsWithTags struct {
 	Capabilities map[string]string `yaml:"Capabilities"`
 	Info         string            `yaml:"Info"`
 	Driver       string            `yaml:"Driver"`
+	Mode         string            `yaml:"Mode"`
+	Path         string            `yaml:"Path"`
 	DevCount     int               `yaml:"DevCount"`
 	TilesPerDev  int               `yaml:"TilesPerDev"`
 	DevMemSize   int               `yaml:"DevMemSize"`
@@ -104,6 +108,8 @@ func convertToGenOptions(withTags genOptionsWithTags) GenOptions {
 		Capabilities: withTags.Capabilities,
 		Info:         withTags.Info,
 		Driver:       withTags.Driver,
+		Mode:         withTags.Mode,
+		Path:         withTags.Path,
 		DevCount:     withTags.DevCount,
 		TilesPerDev:  withTags.TilesPerDev,
 		DevMemSize:   withTags.DevMemSize,


### PR DESCRIPTION
…fix also to api.go which defaults always /dev path.